### PR TITLE
Use xxhash-rust >=0.8.2 to avoid bug in stateful implementation

### DIFF
--- a/native/xxh3/Cargo.toml
+++ b/native/xxh3/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["dylib"]
 
 [dependencies]
 rustler = "0.22.0-rc.0"
-xxhash-rust = { version = "0.8.1", features = ["xxh3"] }
+xxhash-rust = { version = "0.8.2", features = ["xxh3"] }


### PR DESCRIPTION
Unfortunately stateful Xxh3 had bug which resulted in it producing invalid hashes for total length of 1025 and more.
0.8.1 is not a valid version to use now