### PR TITLE
Add Mac M1 build target

### DIFF
--- a/native/xxh3/.cargo/config
+++ b/native/xxh3/.cargo/config
@@ -3,3 +3,9 @@ rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
When using the library on Mac ARM machines, we faced problems with compilation.

Following the fixes in [other NIF library](https://github.com/mischov/meeseeks_html5ever/pull/47), this PR adds a build target for the `darwin` architecture.

Original error:
```
** (Mix) Could not compile dependency :xxh3, "/Users/andrey.pozdnyakov/.asdf/installs/elixir/1.16.3-otp-26/.mix/elixir/1-16/rebar3 bare compile --paths /Users/andrey.pozdnyakov/projects/dummy_elixir/_build/dev/lib/*/ebin" command failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile xxh3 --force", update it with "mix deps.update xxh3" or clean it with "mix deps.clean xxh3"
```

Detailed output (rather large): [output.txt](https://github.com/user-attachments/files/17494512/output.txt)
